### PR TITLE
Fix missing _sdc_deleted_at column in LOG_BASED historic load query

### DIFF
--- a/tap_mssql/sync_strategies/log_based.py
+++ b/tap_mssql/sync_strategies/log_based.py
@@ -226,6 +226,7 @@ def sync_historic_table(mssql_conn, config, catalog_entry, state, columns, strea
             select_sql = """
                             SELECT {}
                                 ,'I' _sdc_operation_type
+                                , null _sdc_deleted_at
                                 , cast('1900-01-01' as datetime) _sdc_lsn_commit_timestamp
                                 , null _sdc_lsn_deleted_at
                                 , '00000000000000000000' _sdc_lsn_value


### PR DESCRIPTION
## Summary

- The SQL query in `sync_historic_table` was missing `null _sdc_deleted_at` as a synthetic column, while `extended_columns` included it
- This one-position offset caused `_sdc_lsn_deleted_at` to receive `'00000000000000000000'` (the placeholder LSN value) instead of `null`
- PostgreSQL rejects `'00000000000000000000'` as a `timestamp` value, raising `DatetimeFieldOverflow` and failing the initial load for any newly added `LOG_BASED` table

## Root Cause

`row_to_singer_record` maps SQL result columns to `extended_columns` by position (via `zip`). The `extended_columns` list has 7 synthetic fields including `_sdc_deleted_at`, but the historic load SQL only projected 6 — skipping `_sdc_deleted_at` entirely. Every subsequent column was therefore shifted one place, landing `'00000000000000000000'` into `_sdc_lsn_deleted_at`.

## Fix

Added `null _sdc_deleted_at` to the `SELECT` in `sync_historic_table` so the SQL output aligns with `extended_columns`.

## Test plan

- [ ] Run a `LOG_BASED` sync on a newly added table (no prior state) and confirm no `DatetimeFieldOverflow` error from the target
- [ ] Verify `_sdc_lsn_deleted_at` is `null` and `_sdc_deleted_at` is `null` for all rows in the initial load
- [ ] Confirm subsequent CDC syncs still emit correct values for both fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)