### PR TITLE
Fixes:  support for binary type columns,  skip invalid tables and skip invalid columns from the cdc tables

### DIFF
--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -728,6 +728,10 @@ def sync_non_cdc_streams(mssql_conn, non_cdc_catalog, config, state):
                 elif replication_method == "LOG_BASED":
                     LOGGER.info(f"syncing {catalog_entry.table} cdc tables")
                     do_sync_historical_log(mssql_conn, config, catalog_entry, state, columns)
+                else:
+                    raise Exception(
+                        "only INCREMENTAL, LOG_BASED and FULL_TABLE replication methods are supported"
+                    )
             except Exception as e:
                 if hasattr(e, "args") and e.args and isinstance(e.args[0], int) and e.args[0] == 208:
                     LOGGER.warning(
@@ -737,10 +741,6 @@ def sync_non_cdc_streams(mssql_conn, non_cdc_catalog, config, state):
                     )
                 else:
                     raise
-            else:
-                raise Exception(
-                    "only INCREMENTAL, LOG_BASED and FULL_TABLE replication methods are supported"
-                )
 
     state = singer.set_currently_syncing(state, None)
     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -624,7 +624,7 @@ def do_sync_historical_log(mssql_conn, config, catalog_entry, state, columns):
     stream_version = common.get_stream_version(catalog_entry.tap_stream_id, state)
 
     # full_table.sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version)
-    log_based.sync_historic_table(mssql_conn, config, catalog_entry, state, columns, stream_version)
+    state = log_based.sync_historic_table(mssql_conn, config, catalog_entry, state, columns, stream_version)
 
     # Prefer initial_full_table_complete going forward
     singer.clear_bookmark(state, catalog_entry.tap_stream_id, "version")

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -624,7 +624,7 @@ def do_sync_historical_log(mssql_conn, config, catalog_entry, state, columns):
     stream_version = common.get_stream_version(catalog_entry.tap_stream_id, state)
 
     # full_table.sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version)
-    state = log_based.sync_historic_table(mssql_conn, config, catalog_entry, state, columns, stream_version)
+    log_based.sync_historic_table(mssql_conn, config, catalog_entry, state, columns, stream_version)
 
     # Prefer initial_full_table_complete going forward
     singer.clear_bookmark(state, catalog_entry.tap_stream_id, "version")

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -718,15 +718,25 @@ def sync_non_cdc_streams(mssql_conn, non_cdc_catalog, config, state):
             timer.tags["database"] = database_name
             timer.tags["table"] = catalog_entry.table
 
-            if replication_method == "INCREMENTAL":
-                LOGGER.info(f"syncing {catalog_entry.table} incrementally")
-                do_sync_incremental(mssql_conn, config, catalog_entry, state, columns)
-            elif replication_method == "FULL_TABLE":
-                LOGGER.info(f"syncing {catalog_entry.table} full table")
-                do_sync_full_table(mssql_conn, config, catalog_entry, state, columns)
-            elif replication_method == "LOG_BASED":
-                LOGGER.info(f"syncing {catalog_entry.table} cdc tables")
-                do_sync_historical_log(mssql_conn, config, catalog_entry, state, columns)
+            try:
+                if replication_method == "INCREMENTAL":
+                    LOGGER.info(f"syncing {catalog_entry.table} incrementally")
+                    do_sync_incremental(mssql_conn, config, catalog_entry, state, columns)
+                elif replication_method == "FULL_TABLE":
+                    LOGGER.info(f"syncing {catalog_entry.table} full table")
+                    do_sync_full_table(mssql_conn, config, catalog_entry, state, columns)
+                elif replication_method == "LOG_BASED":
+                    LOGGER.info(f"syncing {catalog_entry.table} cdc tables")
+                    do_sync_historical_log(mssql_conn, config, catalog_entry, state, columns)
+            except Exception as e:
+                if hasattr(e, "args") and e.args and isinstance(e.args[0], int) and e.args[0] == 208:
+                    LOGGER.warning(
+                        "Skipping table %s: object does not exist in the database (%s)",
+                        catalog_entry.table,
+                        e,
+                    )
+                else:
+                    raise
             else:
                 raise Exception(
                     "only INCREMENTAL, LOG_BASED and FULL_TABLE replication methods are supported"

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -76,6 +76,8 @@ TIME_TYPES = set(["time"])
 
 VARIANT_TYPES = set(["json"])
 
+BINARY_TYPES = set(["binary", "varbinary", "image"])
+
 
 def default_date_format():
     return False
@@ -173,6 +175,10 @@ def schema_for_column(c, config):
 
     elif data_type in VARIANT_TYPES:
         result.type = ["null", "object"]
+
+    elif data_type in BINARY_TYPES:
+        result.type = ["null", "string"]
+        result.format = "binary"
 
     else:
         result = Schema(

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -178,7 +178,6 @@ def schema_for_column(c, config):
 
     elif data_type in BINARY_TYPES:
         result.type = ["null", "string"]
-        result.format = "binary"
 
     else:
         result = Schema(

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -438,6 +438,14 @@ def resolve_catalog(discovered_catalog, streams_to_sync):
         discovered_table = discovered_catalog.get_stream(catalog_entry.tap_stream_id)
         database_name = common.get_database_name(catalog_entry)
 
+        LOGGER.info(
+            "resolve_catalog: tap_stream_id=%s table=%s database=%s found_in_discovery=%s",
+            catalog_entry.tap_stream_id,
+            catalog_entry.table,
+            database_name,
+            discovered_table is not None,
+        )
+
         if not discovered_table:
             LOGGER.warning(
                 "Database %s table %s was selected but does not exist",

--- a/tap_mssql/sync_strategies/common.py
+++ b/tap_mssql/sync_strategies/common.py
@@ -174,13 +174,12 @@ def row_to_singer_record(catalog_entry, version, row, columns, time_extracted, c
             row_to_persist += (timedelta_from_epoch.isoformat() + "+00:00",)
 
         elif isinstance(elem, bytes):
-            # for BIT value, treat 0 as False, 1 as True and anything else as hex
-            if elem == b"\x00":
-                boolean_representation = False
-                row_to_persist += (boolean_representation,)
+            if property_format == "binary":
+                row_to_persist += (str(elem.hex()),)
+            elif elem == b"\x00":
+                row_to_persist += (False,)
             elif elem == b"\x01":
-                boolean_representation = True
-                row_to_persist += (boolean_representation,)
+                row_to_persist += (True,)
             else:
                 row_to_persist += (str(elem.hex()),)
 

--- a/tap_mssql/sync_strategies/common.py
+++ b/tap_mssql/sync_strategies/common.py
@@ -174,7 +174,7 @@ def row_to_singer_record(catalog_entry, version, row, columns, time_extracted, c
             row_to_persist += (timedelta_from_epoch.isoformat() + "+00:00",)
 
         elif isinstance(elem, bytes):
-            if property_format == "binary":
+            if "string" in (property_type if isinstance(property_type, list) else [property_type]):
                 row_to_persist += (str(elem.hex()),)
             elif elem == b"\x00":
                 row_to_persist += (False,)

--- a/tap_mssql/sync_strategies/log_based.py
+++ b/tap_mssql/sync_strategies/log_based.py
@@ -260,8 +260,6 @@ def sync_historic_table(mssql_conn, config, catalog_entry, state, columns, strea
 
     singer.write_message(activate_version_message)
 
-    return state
-
 
 def sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version):
     mssql_conn = MSSQLConnection(config)

--- a/tap_mssql/sync_strategies/log_based.py
+++ b/tap_mssql/sync_strategies/log_based.py
@@ -260,6 +260,8 @@ def sync_historic_table(mssql_conn, config, catalog_entry, state, columns, strea
 
     singer.write_message(activate_version_message)
 
+    return state
+
 
 def sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version):
     mssql_conn = MSSQLConnection(config)

--- a/tap_mssql/sync_strategies/log_based.py
+++ b/tap_mssql/sync_strategies/log_based.py
@@ -109,6 +109,18 @@ def get_to_lsn(connection):
     return row
 
 
+def get_cdc_captured_columns(connection, capture_instance):
+    cur = connection.cursor()
+    cur.execute(
+        """SELECT c.column_name
+           FROM cdc.change_tables ct
+           JOIN cdc.captured_columns c ON c.object_id = ct.object_id
+           WHERE ct.capture_instance = %s""",
+        (capture_instance,),
+    )
+    return {row[0] for row in cur.fetchall()}
+
+
 def add_synthetic_keys_to_schema(catalog_entry):
     catalog_entry.schema.properties["_sdc_operation_type"] = Schema(
         description="Source operation I=Insert, D=Delete, U=Update",
@@ -267,6 +279,21 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version
         generate_bookmark_keys(catalog_entry), catalog_entry.tap_stream_id, state
     )
 
+    cdc_table = common.get_database_name(catalog_entry) + "_" + catalog_entry.table
+    cdc_captured = get_cdc_captured_columns(mssql_conn, cdc_table)
+    # Columns added to the source table after cdc is enabled are not tracked.
+    # We are skipping them here as the incremental run tries to query from the cdc tables where these don't exist
+    
+    if cdc_captured:
+        skipped = set(columns) - cdc_captured
+        if skipped:
+            LOGGER.warning(
+                "Skipping columns not tracked in CDC capture instance %s: %s",
+                cdc_table,
+                skipped,
+            )
+        columns = [c for c in columns if c in cdc_captured]
+
     # Add additional keys to the columns
     extended_columns = columns + [
         "_sdc_operation_type",
@@ -301,9 +328,7 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version
             state_last_lsn = singer.get_bookmark(state, catalog_entry.tap_stream_id, "lsn")
 
             escaped_columns = map(lambda c: common.prepare_columns_sql(catalog_entry, c), columns)
-            table_name = catalog_entry.table
             schema_name = common.get_database_name(catalog_entry)
-            cdc_table = schema_name + "_" + table_name
             escape_table_name = common.escape(catalog_entry.table)
             escaped_schema_name = common.escape(schema_name)
             escaped_cdc_function = common.escape("fn_cdc_get_all_changes_" + cdc_table)


### PR DESCRIPTION
1. Added logic to skip tables if we get an error 208 from sql server. Error 208 corresponds to an invalid/missing object
2. Added logic to skip columns not present in the cdc tables. This can happen when columns are added to the base tables after cdc has been enabled i.e, the base and cdc tables will have a different set of columns where the new columns won't be cdc tracked