### PR TITLE
fix: Remove inaccurate `multipleOf` schema keyword for floating point properties 

### DIFF
--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -126,7 +126,6 @@ def schema_for_column(c, config):
             result.format = "singer.decimal"
         else:
             result.type = ["null", "number"]
-            result.multipleOf = 10 ** (0 - (c.numeric_scale or 17))
 
     elif data_type in DECIMAL_TYPES:
         if use_singer_decimal:


### PR DESCRIPTION
This tap is failing for Imagination with the following error:

```
[info ] target-snowflake for error in errors:
[info ] target-snowflake File "/tmp/shelltaskscripts13726877720856410250/.meltano/loaders/target-snowflake/venv/lib/python3.10/site-packages/jsonschema/_keywords.py", line 296, in properties
[info ] target-snowflake yield from validator.descend(
[info ] target-snowflake File "/tmp/shelltaskscripts13726877720856410250/.meltano/loaders/target-snowflake/venv/lib/python3.10/site-packages/jsonschema/validators.py", line 431, in descend
[info ] target-snowflake for error in errors:
[info ] target-snowflake File "/tmp/shelltaskscripts13726877720856410250/.meltano/loaders/target-snowflake/venv/lib/python3.10/site-packages/jsonschema/_keywords.py", line 188, in multipleOf
[info ] target-snowflake failed = instance % dB
[info ] target-snowflake decimal.InvalidOperation: [<class 'decimal.DivisionImpossible'>]
[error ] meltano
```

It looks like they have a large value in one of their columns and this validation which we have for float type columns is failing. Not sure why this was added in the first place as float columns don't have a fixed decimal scale.

> Approximate-number data types for use with floating point numeric data. Floating point data is approximate; therefore, not all values in the data type range can be represented exactly.

https://learn.microsoft.com/en-us/sql/t-sql/data-types/float-and-real-transact-sql?view=sql-server-ver17

Because values are approximations, it is inaccurate to represent them as a multiple of another.